### PR TITLE
fix: resolve local dev setup issues and analysis flow bugs

### DIFF
--- a/ai-gateway/src/api/health.ts
+++ b/ai-gateway/src/api/health.ts
@@ -31,17 +31,18 @@ async function checkMcpService(url: string, serviceName: string): Promise<Servic
   const startTime = Date.now();
   
   try {
-    // Both MCP servers now have standard /health endpoints
+    // Keycloak MCP has /health; neo4j-mcp only exposes /api/mcp/ (SSE), so check /health
+    // and treat any response (including 404) as "alive" — a 5xx or connection error means down
     const healthPath = '/health';
     const response = await axios.get(`${url}${healthPath}`, {
       timeout: config.HEALTH_CHECK_TIMEOUT,
-      validateStatus: (status) => status < 400 // Standard health check for all services
+      validateStatus: (status) => status < 500 // Accept 4xx too — server is up if it responds
     });
-    
+
     const latency = Date.now() - startTime;
-    
-    // Standard health check for all services
-    const isHealthy = response.status < 400;
+
+    // Consider any response < 500 as healthy (server is reachable and responding)
+    const isHealthy = response.status < 500;
     
     return {
       status: isHealthy ? 'healthy' : 'unhealthy',

--- a/ai-gateway/src/main.ts
+++ b/ai-gateway/src/main.ts
@@ -13,11 +13,11 @@ const server = createServer(app);
 
 // Middleware
 app.use(cors({
-  origin: process.env.NODE_ENV === 'test' 
+  origin: process.env.NODE_ENV === 'test'
     ? true // Allow all origins in test environment
-    : process.env.NODE_ENV === 'production' 
-      ? ['https://your-production-domain.com'] 
-      : ['http://localhost:3000', 'http://localhost:3001'],
+    : process.env.NODE_ENV === 'production'
+      ? ['https://your-production-domain.com']
+      : (process.env.CORS_ORIGINS?.split(',') || ['http://localhost:3000', 'http://localhost:3001', 'http://localhost:3002']),
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization'],

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -13,6 +13,10 @@ const nextConfig = {
         destination: 'http://localhost:3001/:path*',
       },
       {
+        source: '/api/neo4j/health',
+        destination: 'http://localhost:8005/health',  // ai-gateway already checks neo4j status
+      },
+      {
         source: '/api/neo4j/:path*',
         destination: 'http://localhost:8002/:path*',
       },

--- a/frontend/src/components/dashboard/AnalysisPanel.tsx
+++ b/frontend/src/components/dashboard/AnalysisPanel.tsx
@@ -6,6 +6,7 @@ import { useIKASStore } from '@/store';
 export function AnalysisPanel() {
   const { analysis, startAnalysis } = useIKASStore();
   const [selectedAnalysisType, setSelectedAnalysisType] = useState('duplicate-users');
+  const [expandedResultId, setExpandedResultId] = useState<string | null>(null);
   const [analysisParams, setAnalysisParams] = useState({
     realm: 'all',
     includeDisabled: false,
@@ -350,16 +351,61 @@ export function AnalysisPanel() {
                       </p>
                     </div>
                   </div>
-                  
+
                   <div className="flex items-center space-x-4">
                     <span className="text-xs text-gray-500 dark:text-gray-400">
                       {Math.round(item.duration / 1000)}s
                     </span>
-                    <button className="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200 font-medium">
-                      Ergebnisse anzeigen
+                    <button
+                      onClick={() => setExpandedResultId(expandedResultId === item.id ? null : item.id)}
+                      className="text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200 font-medium"
+                    >
+                      {expandedResultId === item.id ? 'Verbergen' : 'Ergebnisse anzeigen'}
                     </button>
                   </div>
                 </div>
+
+                {expandedResultId === item.id && (
+                  <div className="mt-4 p-4 bg-gray-50 dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700">
+                    {item.result ? (
+                      <div className="space-y-3">
+                        {item.result.summary && (
+                          <p className="text-sm text-gray-700 dark:text-gray-300">{item.result.summary}</p>
+                        )}
+                        {item.result.patterns && item.result.patterns.length > 0 ? (
+                          <div>
+                            <h5 className="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide mb-2">
+                              Gefundene Muster ({item.result.patterns.length})
+                            </h5>
+                            <ul className="space-y-1">
+                              {item.result.patterns.map((p: any, i: number) => (
+                                <li key={i} className="text-sm text-gray-700 dark:text-gray-300">
+                                  {typeof p === 'string' ? p : JSON.stringify(p)}
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        ) : item.result.patterns ? (
+                          <p className="text-sm text-gray-500 dark:text-gray-400 italic">Keine Muster gefunden.</p>
+                        ) : null}
+                        {/* Render any other top-level keys */}
+                        {Object.entries(item.result)
+                          .filter(([k]) => k !== 'summary' && k !== 'patterns')
+                          .map(([k, v]) => (
+                            <div key={k}>
+                              <h5 className="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide mb-1">{k}</h5>
+                              <pre className="text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-all">
+                                {typeof v === 'string' ? v : JSON.stringify(v, null, 2)}
+                              </pre>
+                            </div>
+                          ))
+                        }
+                      </div>
+                    ) : (
+                      <p className="text-sm text-gray-500 dark:text-gray-400 italic">Keine Ergebnisdaten verfügbar.</p>
+                    )}
+                  </div>
+                )}
               </div>
             ))
           )}

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -133,6 +133,11 @@ export class WebSocketService {
           this.callHandler('voiceCommandReceived', data);
         });
 
+        this.socket.on('analysisStarted', (data) => {
+          console.log('🔬 Analysis started', data);
+          this.callHandler('analysisStarted', data);
+        });
+
         this.socket.on('subscriptionConfirmed', (data) => {
           console.log('📢 Subscription confirmed', data);
           this.callHandler('subscriptionConfirmed', data);
@@ -307,13 +312,17 @@ export class WebSocketService {
 
     return new Promise((resolve) => {
       const timeout = setTimeout(() => {
+        this.socket?.off('pong', onPong);
         resolve(false);
       }, 5000);
 
-      this.socket!.emit('ping', (response: any) => {
+      const onPong = () => {
         clearTimeout(timeout);
-        resolve(response === 'pong');
-      });
+        resolve(true);
+      };
+
+      this.socket!.once('pong', onPong);
+      this.socket!.emit('ping');
     });
   }
 

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -373,6 +373,21 @@ export const useIKASStore = create<IKASStore>()(
             });
           });
 
+          // Register analysis with server-assigned UUID when confirmed
+          websocketService.on('analysisStarted', (data: { analysisId: string; type: string; timestamp: string }) => {
+            const activeAnalyses = new Map(get().analysis.activeAnalyses);
+            activeAnalyses.set(data.analysisId, {
+              id: data.analysisId,
+              type: data.type,
+              progress: 0,
+              status: 'started',
+              startTime: new Date(data.timestamp)
+            });
+            set((state) => ({
+              analysis: { ...state.analysis, activeAnalyses }
+            }));
+          });
+
           // Handle connection retry events
           websocketService.on('connectionRetrying', (data) => {
             get().addNotification({
@@ -974,9 +989,28 @@ export const useIKASStore = create<IKASStore>()(
             }
             break;
 
+          case EventType.ANALYSIS_STARTED: {
+            // Fallback: create entry if the direct 'analysisStarted' socket event was missed
+            const payload = event.payload as any;
+            const activeAnalyses = new Map(get().analysis.activeAnalyses);
+            if (!activeAnalyses.has(payload.analysisId)) {
+              activeAnalyses.set(payload.analysisId, {
+                id: payload.analysisId,
+                type: payload.analysisType,
+                progress: 0,
+                status: 'started',
+                startTime: new Date(event.timestamp)
+              });
+              set((state) => ({
+                analysis: { ...state.analysis, activeAnalyses }
+              }));
+            }
+            break;
+          }
+
           case EventType.ANALYSIS_PROGRESS:
             get().updateAnalysisProgress(
-              event.payload.analysisId, 
+              event.payload.analysisId,
               event.payload.progress || 0,
               event.payload.status
             );
@@ -1094,24 +1128,7 @@ export const useIKASStore = create<IKASStore>()(
       startAnalysis: async (type: string, parameters: Record<string, any> = {}) => {
         try {
           await websocketService.startAnalysis(type, parameters);
-          
-          const analysisId = `analysis-${Date.now()}`;
-          const activeAnalyses = new Map(get().analysis.activeAnalyses);
-          activeAnalyses.set(analysisId, {
-            id: analysisId,
-            type,
-            progress: 0,
-            status: 'started',
-            startTime: new Date()
-          });
-
-          set((state) => ({
-            analysis: {
-              ...state.analysis,
-              activeAnalyses
-            }
-          }));
-
+          // Analysis tracking is initialized when the server confirms via 'analysisStarted' event
         } catch (error) {
           get().addNotification({
             type: 'error',

--- a/websocket-server/src/server.ts
+++ b/websocket-server/src/server.ts
@@ -414,14 +414,30 @@ class IKASWebSocketServer {
         return;
       }
 
-      const { analysisType, parameters } = data;
+      const { analysisType: rawAnalysisType, parameters } = data;
       const analysisId = randomUUID();
+
+      // Normalize frontend kebab-case IDs to valid Zod enum values
+      const analysisTypeMap: Record<string, 'user_patterns' | 'compliance_check' | 'security_audit' | 'usage_statistics'> = {
+        'duplicate-users': 'user_patterns',
+        'inactive-users': 'user_patterns',
+        'role-analysis': 'user_patterns',
+        'security-audit': 'security_audit',
+        'usage-patterns': 'usage_statistics',
+        'compliance-check': 'compliance_check',
+        // Pass through values that are already valid
+        'user_patterns': 'user_patterns',
+        'compliance_check': 'compliance_check',
+        'security_audit': 'security_audit',
+        'usage_statistics': 'usage_statistics',
+      };
+      const analysisType = analysisTypeMap[rawAnalysisType] || 'user_patterns';
 
       // Create analysis started event
       const analysisEvent = createAnalysisEvent(
         session.id,
         analysisId,
-        analysisType || 'user_patterns',
+        analysisType,
         'started'
       );
 


### PR DESCRIPTION
- ai-gateway: add localhost:3002 to CORS origins and support CORS_ORIGINS env var override
- ai-gateway: accept 2xx-4xx as healthy for neo4j-mcp /health check (returns 404 in native MCP mode)
- frontend/next.config.js: proxy /api/neo4j/health to ai-gateway which aggregates all service status
- websocket.ts: fix testConnection() to use pong event listener instead of ACK callback
- websocket.ts: add 'analysisStarted' socket event listener
- server.ts: normalize frontend kebab-case analysis type IDs to valid Zod enum values
- store: fix analysis ID mismatch — track analyses using server-assigned UUID from 'analysisStarted' event instead of local timestamp ID, preventing progress/completion events from being silently dropped
- store: add ANALYSIS_STARTED handler in handleIncomingEvent as Redis pub/sub fallback
- AnalysisPanel: wire up 'Ergebnisse anzeigen' button with toggling inline result display