### PR TITLE
fix(websocket): resolve analysis errors and silent failure modes

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -179,13 +179,18 @@ services:
     ports:
       - "8005:8005"
     environment:
-      GEMINI_API_KEY: AIzaSyDa1fNkc-LVV7EKhEBHm8VA7yyrpEitje4
+      GEMINI_API_KEY: ${GEMINI_API_KEY:-AIzaSyDa1fNkc-LVV7EKhEBHm8VA7yyrpEitje4}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       REDIS_URL: redis://redis:6379
       KEYCLOAK_MCP_URL: http://keycloak-mcp:8001
       NEO4J_MCP_URL: http://neo4j-mcp:8002
       WEBSOCKET_SERVER_URL: http://websocket-server:3001
       NODE_ENV: development
       PORT: 8005
+      LLM_PROVIDER: ${LLM_PROVIDER:-anthropic}
+      LLM_MODEL: ${LLM_MODEL:-claude-sonnet-4-20250514}
+      LLM_TEMPERATURE: ${LLM_TEMPERATURE:-0.1}
+      LLM_MAX_TOKENS: ${LLM_MAX_TOKENS:-8192}
     depends_on:
       keycloak-mcp:
         condition: service_started

--- a/frontend/src/components/dashboard/IKASDashboard.tsx
+++ b/frontend/src/components/dashboard/IKASDashboard.tsx
@@ -28,23 +28,21 @@ export function IKASDashboard() {
   } = useIKASStore();
 
   const [isInitialized, setIsInitialized] = useState(false);
+  const [initError, setInitError] = useState<string | null>(null);
 
   useEffect(() => {
     const initializeApp = async () => {
       try {
         console.log('🚀 Initializing IKAS Dashboard...');
-        
-        // Initialize services
         await initializeServices();
-        
-        // Connect to WebSocket
         await connectWebSocket('dashboard-user', 'master');
-        
         setIsInitialized(true);
         console.log('✅ IKAS Dashboard initialized successfully');
       } catch (error) {
-        console.error('❌ Failed to initialize IKAS Dashboard:', error);
-        setIsInitialized(false);
+        const msg = error instanceof Error ? error.message : String(error);
+        console.error('❌ Failed to initialize IKAS Dashboard:', msg);
+        setInitError(msg);
+        setIsInitialized(true); // show dashboard anyway so user isn't stuck
       }
     };
 
@@ -69,6 +67,11 @@ export function IKASDashboard() {
 
   return (
     <div className={`min-h-screen ${ui.darkMode ? 'dark' : ''}`}>
+      {initError && (
+        <div className="bg-yellow-50 dark:bg-yellow-900/30 border-b border-yellow-200 dark:border-yellow-700 px-6 py-2 text-sm text-yellow-800 dark:text-yellow-200">
+          WebSocket connection failed: {initError} — some real-time features may be unavailable.
+        </div>
+      )}
       <div className="bg-gray-50 dark:bg-gray-900 transition-colors duration-200">
         {/* Header */}
         <header className="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700">

--- a/frontend/src/services/websocket.ts
+++ b/frontend/src/services/websocket.ts
@@ -15,10 +15,10 @@ export class WebSocketService {
 
   constructor(url?: string) {
     // Use environment variables with fallbacks
-    this.url = url || 
-               process.env.NEXT_PUBLIC_WS_URL || 
+    this.url = url ||
+               process.env.NEXT_PUBLIC_WS_URL ||
                'ws://localhost:3001';
-    
+
     this.maxReconnectAttempts = parseInt(process.env.NEXT_PUBLIC_WS_RECONNECT_ATTEMPTS || '5');
     this.reconnectDelay = parseInt(process.env.NEXT_PUBLIC_WS_RECONNECT_DELAY || '1000');
     this.connectionTimeout = parseInt(process.env.NEXT_PUBLIC_WS_TIMEOUT || '10000');
@@ -76,7 +76,7 @@ export class WebSocketService {
         this.socket.on('connect', () => {
           this.isConnected = true;
           this.reconnectAttempts = 0;
-          
+
           console.log('✅ Connected to IKAS WebSocket server', {
             socketId: this.socket?.id
           });
@@ -99,7 +99,7 @@ export class WebSocketService {
 
         this.socket.on('connect_error', (error) => {
           this.reconnectAttempts++;
-          
+
           const errorDetails = {
             error: error.message,
             attempts: this.reconnectAttempts,
@@ -116,7 +116,7 @@ export class WebSocketService {
               `Check if WebSocket server is running at ${this.url}. ` +
               `Original error: ${error.message}`
             );
-            
+
             this.callHandler('connectionFailed', errorDetails);
             reject(finalError);
           } else {
@@ -143,8 +143,24 @@ export class WebSocketService {
           this.callHandler('subscriptionConfirmed', data);
         });
 
-        this.socket.on('error', (error) => {
-          console.error('⚠️ WebSocket error', error);
+        // serverError: application-level errors sent deliberately by the server
+        // (e.g. session not found, analysis failed). The server sends a plain
+        // object { message: string } so we extract message directly.
+        this.socket.on('serverError', (payload: { message?: string } | unknown) => {
+          const msg =
+            payload && typeof payload === 'object' && 'message' in payload
+              ? String((payload as { message: unknown }).message)
+              : String(payload);
+          console.error('⚠️ WebSocket server error', msg, payload);
+          this.callHandler('serverError', payload);
+        });
+
+        // error: reserved socket.io event for transport-level errors.
+        // The argument here is always an Error instance from the socket.io
+        // client internals, so we can safely access .message.
+        this.socket.on('error', (error: Error) => {
+          const msg = error instanceof Error ? error.message : String(error);
+          console.error('⚠️ WebSocket transport error', msg, error);
           this.callHandler('error', error);
         });
 
@@ -282,7 +298,7 @@ export class WebSocketService {
       this.isConnected = false;
       this.sessionId = null;
       this.eventHandlers.clear();
-      
+
       console.log('🔌 Disconnected from IKAS WebSocket server');
     }
   }
@@ -337,7 +353,7 @@ export class WebSocketService {
     lastPingTime?: number;
   }> {
     const healthy = await this.testConnection();
-    
+
     return {
       connected: this.isConnected,
       socketId: this.socket?.id,
@@ -352,17 +368,17 @@ export class WebSocketService {
   // Force reconnection
   async forceReconnect(userId?: string, realm?: string): Promise<void> {
     console.log('🔄 Forcing WebSocket reconnection...');
-    
+
     if (this.socket) {
       await this.disconnect();
     }
-    
+
     // Reset reconnection attempts
     this.reconnectAttempts = 0;
-    
+
     // Wait a moment before reconnecting
     await new Promise(resolve => setTimeout(resolve, 1000));
-    
+
     return this.connect(userId, realm);
   }
 }

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -417,6 +417,20 @@ export const useIKASStore = create<IKASStore>()(
             });
           });
 
+          // Handle application-level errors sent by the server (session not found,
+          // analysis failures, etc.). Payload is { message: string }.
+          websocketService.on('serverError', (payload: { message?: string } | unknown) => {
+            const msg =
+              payload && typeof payload === 'object' && 'message' in payload
+                ? String((payload as { message: unknown }).message)
+                : 'An error occurred on the server';
+            get().addNotification({
+              type: 'error',
+              title: 'Server Error',
+              message: msg
+            });
+          });
+
           // Subscribe to all event types
           await websocketService.subscribe({
             eventTypes: Object.values(EventType),

--- a/websocket-server/src/server.ts
+++ b/websocket-server/src/server.ts
@@ -195,7 +195,7 @@ class IKASWebSocketServer {
     try {
       const session = await this.sessionManager.getSessionBySocket(socket.id);
       if (!session) {
-        socket.emit('error', { message: 'Session not found' });
+        socket.emit('serverError', { message: 'Session not found' });
         return;
       }
 
@@ -227,7 +227,7 @@ class IKASWebSocketServer {
         socketId: socket.id,
         data
       });
-      socket.emit('error', { 
+      socket.emit('serverError', { 
         message: 'Error processing voice command' 
       });
     }
@@ -237,7 +237,7 @@ class IKASWebSocketServer {
     try {
       const session = await this.sessionManager.getSessionBySocket(socket.id);
       if (!session) {
-        socket.emit('error', { message: 'Session not found' });
+        socket.emit('serverError', { message: 'Session not found' });
         return;
       }
 
@@ -269,7 +269,7 @@ class IKASWebSocketServer {
         socketId: socket.id,
         data
       });
-      socket.emit('error', { 
+      socket.emit('serverError', { 
         message: 'Error processing text command' 
       });
     }
@@ -279,7 +279,7 @@ class IKASWebSocketServer {
     try {
       const session = await this.sessionManager.getSessionBySocket(socket.id);
       if (!session) {
-        socket.emit('error', { message: 'Session not found' });
+        socket.emit('serverError', { message: 'Session not found' });
         return;
       }
 
@@ -311,7 +311,7 @@ class IKASWebSocketServer {
         socketId: socket.id,
         data
       });
-      socket.emit('error', { 
+      socket.emit('serverError', { 
         message: 'Error creating subscription' 
       });
     }
@@ -353,7 +353,7 @@ class IKASWebSocketServer {
     try {
       const session = await this.sessionManager.getSessionBySocket(socket.id);
       if (!session) {
-        socket.emit('error', { message: 'Session not found' });
+        socket.emit('serverError', { message: 'Session not found' });
         return;
       }
 
@@ -367,7 +367,7 @@ class IKASWebSocketServer {
           timestamp: new Date().toISOString()
         });
       } else {
-        socket.emit('error', { 
+        socket.emit('serverError', { 
           message: `Unable to join room '${room}'` 
         });
       }
@@ -410,7 +410,7 @@ class IKASWebSocketServer {
     try {
       const session = await this.sessionManager.getSessionBySocket(socket.id);
       if (!session) {
-        socket.emit('error', { message: 'Session not found' });
+        socket.emit('serverError', { message: 'Session not found' });
         return;
       }
 
@@ -458,7 +458,7 @@ class IKASWebSocketServer {
         socketId: socket.id,
         data
       });
-      socket.emit('error', { 
+      socket.emit('serverError', { 
         message: 'Error starting analysis' 
       });
     }


### PR DESCRIPTION
## Summary

- **Missing `frontend/.env.local`** caused Next.js to silently ignore `NEXT_PUBLIC_WS_URL` from the root `.env`, making the WebSocket service fall back to the wrong `ws://` protocol and fail to connect
- **Reserved Socket.io `error` event collision** caused the server's application errors to arrive as `[object Object]` — the server was using `socket.emit('error', { message })` which clashes with Socket.io's internal transport error event name
- **Dashboard infinite spinner** meant any WebSocket failure left the entire UI locked on loading with no escape or feedback

## Changes

| File | What changed |
|---|---|
| `frontend/.env.local` | Created — provides `NEXT_PUBLIC_WS_URL` and `NEXT_PUBLIC_API_URL` to Next.js |
| `docker/docker-compose.dev.yml` | `ai-gateway` service now passes `ANTHROPIC_API_KEY`, `LLM_PROVIDER`, and model config from env |
| `websocket-server/src/server.ts` | All `socket.emit('error', ...)` → `socket.emit('serverError', ...)` to avoid Socket.io reserved event collision |
| `frontend/src/services/websocket.ts` | Added `serverError` listener with correct `payload.message` extraction; retained `error` listener for transport errors only |
| `frontend/src/store/index.ts` | Registered `serverError` handler to surface actual error message as a user-facing notification |
| `frontend/src/components/dashboard/IKASDashboard.tsx` | Escapes infinite spinner on WS failure; shows yellow warning banner instead |

## Lessons Learned

### 1. Next.js env file scoping
`NEXT_PUBLIC_*` variables are only picked up from env files **inside the Next.js project directory** (`frontend/`). A `.env` at the monorepo root is invisible to the Next.js dev server. Each service in a monorepo needs its own env file.

### 2. Socket.io reserved event names
Socket.io reserves the `error` event on both client and server for **transport-level** failures. Emitting application errors as `socket.emit('error', payload)` causes ambiguity: the payload arrives as a plain object rather than an `Error` instance, `String(payload)` produces `"[object Object]"`, and the error is completely opaque in the console. Always use a custom event name (e.g. `serverError`, `appError`) for application-level errors.

### 3. `Error` objects are opaque when logged directly
`Error` instances have no enumerable own properties, so `console.error('msg', errorObj)` prints `{}` for the object portion. Always extract `error.message` (or `error.stack`) explicitly when logging.

### 4. Never leave a UI in an unrecoverable loading state
If initialization can fail, the loading screen must have an exit condition. Set a flag and show a degraded-but-functional UI rather than blocking indefinitely.

## FAQ

**Q: Why does `frontend/.env.local` not exist in the repo?**
A: `.env.local` is gitignored by Next.js convention (it typically holds secrets). A `.env.local.example` should be added to document the required variables — tracked as a follow-up.

**Q: Why rename to `serverError` instead of just fixing the client handler?**
A: Using Socket.io's reserved `error` event for application errors is semantically incorrect and creates future confusion. The server should be explicit about what it is emitting. The rename makes intent clear and avoids any current or future Socket.io version quirks around the reserved name.

**Q: Do I need to rebuild the Docker image after this change?**
A: Yes — `websocket-server/src/server.ts` runs inside Docker. After pulling this branch, run:
```bash
docker-compose -f docker/docker-compose.dev.yml build websocket-server
docker-compose -f docker/docker-compose.dev.yml up -d websocket-server
```

**Q: Will this break existing WebSocket clients that listen for `error`?**
A: No. The client `error` listener is retained for genuine Socket.io transport errors. Application errors now arrive on `serverError` — any client code listening to `error` for application errors was already broken (receiving `[object Object]`), so this is a fix not a breaking change.

## Test plan

- [x] Fresh stack startup: `./scripts/start-dev.sh` completes without postgres volume mismatch
- [x] Frontend connects to WebSocket on page load (no spinner stuck, no `[object Object]` error)
- [x] Running an analysis returns results or shows a readable error message (not `[object Object]`)
- [x] Triggering a server-side error shows the actual message in the UI notification
- [x] `docker-compose ... build websocket-server && up -d` succeeds after pulling

🤖 Generated with [Claude Code](https://claude.com/claude-code)