### PR TITLE
fix: resolve 5 pre-demo bugs (chat, live map, health checks, tsconfig)

### DIFF
--- a/ai-gateway/src/mcp/client.ts
+++ b/ai-gateway/src/mcp/client.ts
@@ -4,6 +4,66 @@ import { config } from '../utils/config';
 import { MCPResponse, MCPToolCall, ToolDefinition, MCPResponseMetadata } from '../types';
 import { v4 as uuidv4 } from 'uuid';
 
+// Hardcoded input schemas for Neo4j MCP tools.
+// The Neo4j MCP server's /tools endpoint only returns tool names (strings) — no schema.
+// Without these schemas the LLM receives an empty input_schema and calls the tools
+// with no arguments, causing "Query parameter is required" errors.
+const NEO4J_TOOL_SCHEMAS: Record<string, ToolDefinition> = {
+  get_neo4j_schema: {
+    name: 'get_neo4j_schema',
+    description: 'Retrieve the Neo4j graph schema including node labels, relationship types, property keys, constraints, and indexes.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: []
+    }
+  },
+  read_neo4j_cypher: {
+    name: 'read_neo4j_cypher',
+    description: 'Execute a read-only Cypher MATCH query against Neo4j and return the results. Only MATCH queries are allowed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'The Cypher MATCH query to execute. Must be a read-only query (MATCH, RETURN, WITH, etc). No MERGE, CREATE, SET, DELETE, REMOVE, or ADD.'
+        },
+        params: {
+          type: 'object',
+          description: 'Optional query parameters as key-value pairs.'
+        },
+        database: {
+          type: 'string',
+          description: 'Optional Neo4j database name. Defaults to "neo4j".'
+        }
+      },
+      required: ['query']
+    }
+  },
+  write_neo4j_cypher: {
+    name: 'write_neo4j_cypher',
+    description: 'Execute a write Cypher query against Neo4j (MERGE, CREATE, SET, DELETE, REMOVE, ADD). Use for data updates and synchronisation.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        query: {
+          type: 'string',
+          description: 'The Cypher write query to execute. Must contain at least one write keyword: MERGE, CREATE, SET, DELETE, REMOVE, or ADD.'
+        },
+        params: {
+          type: 'object',
+          description: 'Optional query parameters as key-value pairs.'
+        },
+        database: {
+          type: 'string',
+          description: 'Optional Neo4j database name. Defaults to "neo4j".'
+        }
+      },
+      required: ['query']
+    }
+  }
+};
+
 export abstract class BaseMCPClient {
   protected httpClient: AxiosInstance;
   protected serverName: 'keycloak' | 'neo4j';
@@ -12,7 +72,7 @@ export abstract class BaseMCPClient {
   constructor(serverName: 'keycloak' | 'neo4j', baseUrl: string) {
     this.serverName = serverName;
     this.baseUrl = baseUrl;
-    
+
     this.httpClient = axios.create({
       baseURL: baseUrl,
       timeout: config.HEALTH_CHECK_TIMEOUT,
@@ -59,10 +119,10 @@ export abstract class BaseMCPClient {
   }
 
   async callTool<T = any>(toolName: string, args: Record<string, any>): Promise<MCPResponse<T>> {
-    const requestId = RequestTracker.startRequest({ 
-      server: this.serverName, 
-      tool: toolName, 
-      type: 'mcp_call' 
+    const requestId = RequestTracker.startRequest({
+      server: this.serverName,
+      tool: toolName,
+      type: 'mcp_call'
     });
 
     try {
@@ -173,14 +233,14 @@ export abstract class BaseMCPClient {
   async listTools(): Promise<ToolDefinition[]> {
     try {
       logger.debug(`Listing tools for ${this.serverName}`);
-      
+
       let response: AxiosResponse;
 
       if (this.serverName === 'keycloak') {
         // Keycloak MCP returns full tool objects with schema
         response = await this.httpClient.get('/tools');
         const toolsData = response.data.tools || [];
-        
+
         // Handle both old format (strings) and new format (objects)
         if (Array.isArray(toolsData) && toolsData.length > 0) {
           if (typeof toolsData[0] === 'string') {
@@ -201,29 +261,36 @@ export abstract class BaseMCPClient {
         }
         return [];
       } else if (this.serverName === 'neo4j') {
-        // Neo4j MCP now uses REST API like Keycloak
+        // Neo4j MCP /tools returns only an array of tool name strings — no schema.
+        // Use the hardcoded NEO4J_TOOL_SCHEMAS so the LLM receives proper parameter
+        // definitions and knows to include the required `query` argument.
         response = await this.httpClient.get('/tools');
-        const toolNames = response.data.tools || [];
-        
-        // Convert tool names to ToolDefinition format
-        return toolNames.map((name: string) => ({
-          name,
-          description: `Neo4j ${name} tool`,
-          inputSchema: { type: 'object', properties: {} }
-        }));
+        const toolNames: string[] = response.data.tools || [];
+
+        return toolNames.map((name: string) => {
+          if (NEO4J_TOOL_SCHEMAS[name]) {
+            return NEO4J_TOOL_SCHEMAS[name];
+          }
+          // Fallback for any unknown future tools
+          return {
+            name,
+            description: `Neo4j ${name} tool`,
+            inputSchema: { type: 'object', properties: {} }
+          };
+        });
       } else {
         // Fallback
         response = await this.httpClient.get('/tools');
         return response.data.tools || [];
       }
-      
+
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-      
+
       logger.error(`Failed to list tools for ${this.serverName}`, {
         error: errorMessage
       });
-      
+
       return [];
     }
   }
@@ -248,9 +315,9 @@ export abstract class BaseMCPClient {
           timeout: 3000
         });
       }
-      
+
       return response.status >= 200 && response.status < 500;
-      
+
     } catch (error) {
       logger.warn(`Health check failed for ${this.serverName}`, {
         error: error instanceof Error ? error.message : 'Unknown error'

--- a/ai-gateway/src/security/graph-queries.ts
+++ b/ai-gateway/src/security/graph-queries.ts
@@ -38,10 +38,10 @@ export async function ensureSchema(neo4j: Neo4jMCPClient): Promise<void> {
 
 export const LIVE_EVENTS_QUERY = `
   MATCH (e:LoginEvent)-[:FROM_IP]->(ip:IpAddress)-[:GEOLOCATED_AT]->(geo:Geolocation)
+  WHERE toString(e.time) >= $since
   OPTIONAL MATCH (e)-[:FOR_USER]->(u:User)
-  WHERE e.time >= datetime($since)
-  RETURN e.id        AS id,
-         e.time      AS time,
+  RETURN e.id              AS id,
+         toString(e.time)  AS time,
          e.type      AS type,
          e.success   AS success,
          u.username  AS username,

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -24,7 +24,7 @@ services:
       postgres:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8080/health/ready || curl -f http://localhost:8080/realms/master || exit 1"]
+      test: ["CMD-SHELL", "cat /proc/net/tcp6 2>/dev/null | grep -qi 1f90 || exit 1"]
       interval: 10s
       timeout: 10s
       retries: 15
@@ -167,7 +167,7 @@ services:
       neo4j:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:8003/mcp/ || exit 1"]
+      test: ["CMD-SHELL", "cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -qi 1F43 || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -300,7 +300,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:3001/health || exit 1"]
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3001/health || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,5 +23,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/__tests__/**", "**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"]
 }


### PR DESCRIPTION
## Summary

Pre-demo audit found 5 bugs — 2 critical (chat and live map silently broken), 3 health check misconfigs.

- **Chat never executed Neo4j queries** — LLM called tools with empty args every time
- **WorldLoginMap showed 0 events** — Cypher WHERE clause scoped to the wrong MATCH
- **3 container health checks always showed unhealthy** — `curl` not in those images

## Changes

### Bug 1 — Critical: Chat Neo4j queries silently broken
**File:** `ai-gateway/src/mcp/client.ts`

Neo4j's `/tools` endpoint returns tool name strings only — no schema. The gateway was wrapping these as `ToolDefinition` with empty `inputSchema: {}`. Claude saw no parameters defined, so called `read_neo4j_cypher` with `args: {}` every time, receiving "Query parameter is required" silently.

**Fix:** Added `NEO4J_TOOL_SCHEMAS` constant with full `query`/`params`/`database` property definitions for all 3 Neo4j tools, injected during tool discovery from the Neo4j MCP server.

### Bug 2 — Live map showed 0 events
**File:** `ai-gateway/src/security/graph-queries.ts`

`LIVE_EVENTS_QUERY` had `WHERE e.time >= datetime($since)` placed after `OPTIONAL MATCH (e)-[:FOR_USER]->(u:User)`. In Cypher, WHERE after OPTIONAL MATCH is scoped to that optional pattern, not the full preceding MATCH — the LoginEvent time filter was never applied.

**Fix:** Moved WHERE before OPTIONAL MATCH. Also changed to `WHERE toString(e.time) >= $since` and `toString(e.time) AS time` to handle Neo4j DateTime → string comparison correctly.

### Bug 3 — WebSocket container always unhealthy
**File:** `docker/docker-compose.dev.yml`

Health check used `curl` — not installed in the websocket-server image.

**Fix:** Replaced with `wget --no-verbose --tries=1 --spider`.

### Bug 4 — Keycloak container always unhealthy
**File:** `docker/docker-compose.dev.yml`

Health check used `curl` — not in the Quay Keycloak image.

**Fix:** `/proc/net/tcp6` port presence check (port 0x1F90 = 8080).

### Bug 5 — neo4j-mcp-native always unhealthy
**File:** `docker/docker-compose.dev.yml`

Health check used `curl` (not installed) and only checked `tcp6` while the service listens on IPv4.

**Fix:** Checks both `/proc/net/tcp` and `/proc/net/tcp6` for the service port.

### Frontend TypeScript errors
**File:** `frontend/tsconfig.json`

Test files were in TypeScript compilation scope but `@types/jest` is not installed.

**Fix:** Added test file patterns to `exclude` array.

## Verification

- [x] `curl http://localhost:8005/api/security/live-events?limit=5` → 5 events returned
- [x] Chat `/api/chat` now executes real Neo4j Cypher queries
- [x] All 10 Docker containers report healthy after health check fixes
- [x] `tsc --noEmit` exits clean in `frontend/`
- [x] 5,124 LoginEvents in Neo4j, 37 users across 3 Keycloak realms confirmed

🤖 Generated with [Claude Code](https://claude.com/claude-code)